### PR TITLE
docs: mianesp deps track main, not the merged idf6 branch

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,5 +1,5 @@
 dependencies:
-  # Shared infrastructure — mianesp repo, IDF v6 branch.
+  # Shared infrastructure — mianesp repo, main branch.
   jsonwrapper:
     git: git@github.com:mianos/mianesp.git
     path: components/jsonwrapper


### PR DESCRIPTION
Deps already pinned to main; correct the stale 'IDF v6 branch' comment now that idf6-network-provisioning is merged into mianesp main (PR #1).